### PR TITLE
Minordepthtweaks

### DIFF
--- a/R/nc-utils.r
+++ b/R/nc-utils.r
@@ -1,6 +1,6 @@
 
 #' Read the variable as is
-#' 
+#'
 #' @param x netcdf file path
 #' @param varname variable name
 #' @param ... dots (ignored)
@@ -14,11 +14,11 @@ rawdata.character <- function(x, varname, ...) {
 #' @name rawdata
 #' @export
 rawdata.NetCDF <- function(x, varname, ...) {
-  rawdata(nc$file$filename[1L], varname = varname, ...)
+  rawdata(x$file$filename[1L], varname = varname, ...)
 }
 
 
-#' @importFrom ncdf4 nc_open nc_close ncvar_get 
+#' @importFrom ncdf4 nc_open nc_close ncvar_get
 ncget <- function(x, varname) {
   nc <- ncdf4::nc_open(x)
   on.exit(ncdf4::nc_close(nc))

--- a/R/roms_h.R
+++ b/R/roms_h.R
@@ -1,53 +1,52 @@
 #' Coordinates at depth
-#' 
+#'
 #' Extract the multi-layer 'h'eight grid with S-coordinate stretching applied
-#' 
+#'
 #' Compute ROMS grid depth from vertical stretched variables
 #' Given a bathymetry (h), free-surface (zeta) and terrain-following parameters, this function computes the 3D depths for the requested C-grid location. If the free-surface is not provided, a zero value is assumed resulting in unperturb depths.  This function can be used when generating initial conditions or climatology data for an application. Check the following link for details: https://www.myroms.org/wiki/index.php/Vertical_S-coordinate
 #' See https://github.com/dcherian/tools/blob/master/ROMS/arango/utility/set_depth.m
-#' Original Matlab code by Deepak Cherian. 
-#'  \code{S} and \code{h} are the  names of the appropriate variables
-#' @param x ROMS file name 
+#' Original Matlab code by Hernan Arango.
+#' @param x ROMS file name
 #' @param grid_type string: "rho","psi","u","v","w"
 #' @param slice integer: if non-missing, use this time slice to index into zeta (free-surface). Otherwise assume zeta is zero (and hence depth is time-independent)
 #' @param ... dots
-#' @param depth depth thing
-#' @param S  of S-coordinate stretching curve at RHO-points
+#' @param depth string: the name of the appropriate variable to use for depth
 #' @return RasterStack with a layer for every depth
 #' @export
-romshcoords <- function(x, grid_type = "rho", slice, ..., S = "Cs_r", depth = "h", simple = FALSE){
+romshcoords <- function(x, grid_type = "rho", slice, ..., depth = "h", simple = FALSE){
+  grid_type <- match.arg(tolower(grid_type),c("rho","psi","u","v","w"))
+  S <- if (grid_type=="w") "Cs_w" else "Cs_r"
   h <- romsdata(x, varname = depth)
   Cs_r <- ncget(x, S)
   v <- values(h)
   if (simple) {
     ## simplistic, early version - probably should be defunct
-    out <- set_indextent(brick(array(rep(rev(Cs_r), each = length(v)) * v, 
+    out <- set_indextent(brick(array(rep(rev(Cs_r), each = length(v)) * v,
                                      c(ncol(h), nrow(h), length(Cs_r))), transpose = TRUE))
   } else {
-    grid_type <- match.arg(tolower(grid_type),c("rho","psi","u","v","w"))
-    
+
     Vtransform <- as.integer(ncget(x,"Vtransform"))
     if (!Vtransform %in% c(1,2)) stop("Vtransform must be 1 or 2")
-    
+
     hc <- ncget(x,"hc")
-    
+
     depth_grid <- if (grid_type=="w") "w" else "rho"
-    
+
     zeta <- if (missing(slice)) 0 else stop("not coded yet")##angstroms::romsdata2d(x,"zeta",slice=slice,transpose=FALSE)
     N <- length(ncget(x,"Cs_r"))
     Np <- N+1
-    
+
     h <- ncget(x,"h")
     hmin <- min(h)
     hmax <- max(h)
-    
+
     Lp <- dim(h)[1]
     Mp <- dim(h)[2]
     L <- Lp-1
     M <- Mp-1
-    
+
     z <- array(NA,dim=c(Lp,Mp,if (grid_type=="w") Np else N))
-    
+
     ## Compute vertical stretching function, C(k):
     ##stretch <- stretching(x,depth_grid)
     if (depth_grid=="w") {
@@ -55,7 +54,7 @@ romshcoords <- function(x, grid_type = "rho", slice, ..., S = "Cs_r", depth = "h
     } else {
       stretch <- list(C=ncget(x,"Cs_r"),s=ncget(x,"s_rho"))
     }
-    
+
     ## Average bathymetry and free-surface at requested C-grid type.
     if (grid_type=="rho") {
       hr <- h
@@ -75,9 +74,9 @@ romshcoords <- function(x, grid_type = "rho", slice, ..., S = "Cs_r", depth = "h
     } else {
       stop("unsupported grid_type: ",grid_type)
     }
-    
+
     ## Compute depths (m) at requested C-grid location.
-    
+
     if (Vtransform == 1) {
       if (grid_type=="rho") {
         for (k in seq_len(N)) {
@@ -144,9 +143,9 @@ romshcoords <- function(x, grid_type = "rho", slice, ..., S = "Cs_r", depth = "h
     ## though should layers start at the surface and go down or ...
     out <- raster::flip(set_indextent(raster::brick(z, transpose = TRUE)), "y")
     out <- raster::subset(out, rev(seq_len(raster::nlayers(out))))
-    
-  } 
-  
+
+  }
+
  out
 }
 
@@ -154,7 +153,7 @@ romshcoords <- function(x, grid_type = "rho", slice, ..., S = "Cs_r", depth = "h
 #' @name romshcoords
 #' @export
 romsdepth <- function(x, ...) {...
- romshcoords(x, ...) 
+ romshcoords(x, ...)
 }
-  
-  
+
+

--- a/R/roms_h.R
+++ b/R/roms_h.R
@@ -11,6 +11,7 @@
 #' @param slice integer: if non-missing, use this time slice to index into zeta (free-surface). Otherwise assume zeta is zero (and hence depth is time-independent)
 #' @param ... dots
 #' @param depth string: the name of the appropriate variable to use for depth
+#' @param simple logical: if TRUE, use the old "simple" depth method, which may not be correct
 #' @return RasterStack with a layer for every depth
 #' @export
 romshcoords <- function(x, grid_type = "rho", slice, ..., depth = "h", simple = FALSE){

--- a/man/romshcoords.Rd
+++ b/man/romshcoords.Rd
@@ -20,6 +20,8 @@ romsdepth(x, ...)
 \item{...}{dots}
 
 \item{depth}{string: the name of the appropriate variable to use for depth}
+
+\item{simple}{logical: if TRUE, use the old "simple" depth method, which may not be correct}
 }
 \value{
 RasterStack with a layer for every depth

--- a/man/romshcoords.Rd
+++ b/man/romshcoords.Rd
@@ -6,8 +6,7 @@
 \alias{romsdepth}
 \title{Coordinates at depth}
 \usage{
-romshcoords(x, grid_type = "rho", slice, ..., S = "Cs_r", depth = "h",
-  simple = FALSE)
+romshcoords(x, grid_type = "rho", slice, ..., depth = "h", simple = FALSE)
 
 romsdepth(x, ...)
 }
@@ -20,9 +19,7 @@ romsdepth(x, ...)
 
 \item{...}{dots}
 
-\item{S}{of S-coordinate stretching curve at RHO-points}
-
-\item{depth}{depth thing}
+\item{depth}{string: the name of the appropriate variable to use for depth}
 }
 \value{
 RasterStack with a layer for every depth
@@ -34,6 +31,5 @@ Extract the multi-layer 'h'eight grid with S-coordinate stretching applied
 Compute ROMS grid depth from vertical stretched variables
 Given a bathymetry (h), free-surface (zeta) and terrain-following parameters, this function computes the 3D depths for the requested C-grid location. If the free-surface is not provided, a zero value is assumed resulting in unperturb depths.  This function can be used when generating initial conditions or climatology data for an application. Check the following link for details: https://www.myroms.org/wiki/index.php/Vertical_S-coordinate
 See https://github.com/dcherian/tools/blob/master/ROMS/arango/utility/set_depth.m
-Original Matlab code by Deepak Cherian.
-\code{S} and \code{h} are the  names of the appropriate variables
+Original Matlab code by Hernan Arango.
 }


### PR DESCRIPTION
Don't need `S` as a separate parameter to romshcoords, because specifying `grid_type` also determines the appropriate S to use. And a couple of other minor patchups.
